### PR TITLE
Add files via upload

### DIFF
--- a/handling-incomplete-chunking.xml
+++ b/handling-incomplete-chunking.xml
@@ -1,0 +1,8 @@
+<!-- Default behavior is for Akamai to send zero byte chunk to indicate end of stream -->
+<match:variable name="PMUSER_INCOMPLETE_CHUNKING" value="?*" value-wildcard="on" result="false">
+    <network:http.handle-incomplete-chunking.status>on</network:http.handle-incomplete-chunking.status>
+</match:variable>
+<!-- Instructs Akamai edge to not send zero byte chunk. Non-termination of stream from origin makes it to client -->
+<match:variable name="PMUSER_INCOMPLETE_CHUNKING" value="?*" value-wildcard="on">
+    <network:http.handle-incomplete-chunking.status>off</network:http.handle-incomplete-chunking.status>
+</match:variable>


### PR DESCRIPTION
Logic to disable handling of incomplete chunked responses on Akamai. Per AKATEC communication, when set to on Akamai server will treat a file delivered with incomplete chunking as though the file is complete.